### PR TITLE
Add support for savestates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ host
 *.map
 *.user
 .vs
-GoLEm*
+GoLEm_*
+GoLEm.zip
 !golem/
 
 # Rust stuff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "ouroboros",
+ "parking_lot",
  "qrcode",
  "regex",
  "reqwest",

--- a/cyclone_v/src/memory.rs
+++ b/cyclone_v/src/memory.rs
@@ -47,7 +47,10 @@ pub trait MemoryMapper {
     /// Returns a mutable pointer to the mapped memory region.
     fn as_mut_ptr<T>(&mut self) -> *mut T;
 
-    /// Creates an inner range of bytes.
+    /// Creates an inner range of bytes. The offsets are relative to the base
+    /// of the mapped memory, e.g. `as_range(0..4)` will return the first 4
+    /// bytes of the mapped memory (a memory mapping to address 0x12340000 will
+    /// map 0x12340000..0x12340004).
     fn as_range(&self, range: impl RangeBounds<usize>) -> &[u8] {
         let (start, len) = clamp_range(range, self.len());
         unsafe { std::slice::from_raw_parts(self.as_ptr::<u8>().add(start), len) }

--- a/cyclone_v/src/memory.rs
+++ b/cyclone_v/src/memory.rs
@@ -91,7 +91,7 @@ impl<'a> MemoryMapper for RegionMemoryMapper<'a> {
 #[test]
 fn range_works() {
     let data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-    let mut data2 = data.clone();
+    let mut data2 = data;
     let mut mapper = RegionMemoryMapper::new(&mut data2);
     assert_eq!(mapper.as_range(..), &data);
     assert_eq!(mapper.as_range(0..99), &data);

--- a/golem-db/migrations/2024-01-08-173736_save_states/down.sql
+++ b/golem-db/migrations/2024-01-08-173736_save_states/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS "savestates";

--- a/golem-db/migrations/2024-01-08-173736_save_states/up.sql
+++ b/golem-db/migrations/2024-01-08-173736_save_states/up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE savestates
+(
+    id              INTEGER PRIMARY KEY           NOT NULL,
+    name            VARCHAR,
+    core_id         INTEGER REFERENCES cores (id) NOT NULL,
+    game_id         INTEGER REFERENCES games (id) NOT NULL,
+
+    path            VARCHAR                       NOT NULL,
+    screenshot_path VARCHAR,
+
+    favorite        BOOLEAN                       NOT NULL DEFAULT FALSE,
+
+    created_at      DATETIME                      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_played     DATETIME                               DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/golem-db/src/lib.rs
+++ b/golem-db/src/lib.rs
@@ -1,5 +1,6 @@
 pub use diesel;
 use diesel::sqlite::Sqlite;
+use diesel::{sql_query, RunQueryDsl};
 
 pub mod models;
 pub mod schema;
@@ -10,6 +11,9 @@ pub fn establish_connection(
     database_url: &str,
 ) -> Result<Connection, Box<dyn std::error::Error + Send + Sync + 'static>> {
     let mut conn = diesel::Connection::establish(database_url)?;
+
+    // Make sure we're in WAL mode.
+    sql_query("PRAGMA journal_mode=WAL;").execute(&mut conn)?;
 
     run_migrations(&mut conn)?;
     Ok(conn)

--- a/golem-db/src/models.rs
+++ b/golem-db/src/models.rs
@@ -6,3 +6,6 @@ pub use games::*;
 
 mod dat_files;
 pub use dat_files::*;
+
+mod savestates;
+pub use savestates::*;

--- a/golem-db/src/models/games.rs
+++ b/golem-db/src/models/games.rs
@@ -36,7 +36,7 @@ impl GameOrder {
     }
 }
 
-#[derive(Debug, Queryable, Selectable, Identifiable)]
+#[derive(Clone, Debug, Queryable, Selectable, Identifiable)]
 #[diesel(table_name = schema::games)]
 #[diesel(belongs_to(Core))]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]

--- a/golem-db/src/models/savestates.rs
+++ b/golem-db/src/models/savestates.rs
@@ -1,0 +1,75 @@
+use crate::schema;
+use diesel::prelude::*;
+
+#[derive(Clone, Debug, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = crate::schema::savestates)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub struct SaveState {
+    pub id: i32,
+
+    /// The name of this core.
+    pub name: Option<String>,
+
+    /// The core this savestate is linked to.
+    pub core_id: i32,
+
+    /// The game this savestate is linked to.
+    pub game_id: i32,
+
+    /// The path to the savestate's image (.ss file).
+    pub path: String,
+
+    /// The path to the savestate's screenshot, if available.
+    pub screenshot_path: Option<String>,
+
+    /// Whether this savestate is a favorite.
+    pub favorite: bool,
+
+    /// When this was created.
+    pub created_at: chrono::NaiveDateTime,
+
+    /// The last time this savestate was loaded.
+    pub last_played: Option<chrono::NaiveDateTime>,
+}
+
+impl SaveState {
+    pub fn get(
+        conn: &mut crate::Connection,
+        id: i32,
+    ) -> Result<Option<Self>, diesel::result::Error> {
+        schema::savestates::table.find(id).first(conn).optional()
+    }
+
+    pub fn list_for_game(
+        conn: &mut crate::Connection,
+        id: i32,
+    ) -> Result<Vec<Self>, diesel::result::Error> {
+        use schema::savestates::dsl;
+        schema::savestates::table
+            .select(schema::savestates::all_columns)
+            .filter(dsl::game_id.eq(id))
+            .load(conn)
+    }
+
+    pub fn create(
+        conn: &mut crate::Connection,
+        core_id: i32,
+        game_id: i32,
+        path: String,
+        screenshot_path: Option<String>,
+    ) -> Result<Self, diesel::result::Error> {
+        use schema::savestates::dsl;
+        diesel::insert_into(schema::savestates::table)
+            .values((
+                dsl::core_id.eq(core_id),
+                dsl::game_id.eq(game_id),
+                dsl::path.eq(path),
+                dsl::screenshot_path.eq(screenshot_path),
+            ))
+            .execute(conn)?;
+        schema::savestates::table
+            .select(schema::savestates::all_columns)
+            .order(dsl::id.desc())
+            .first(conn)
+    }
+}

--- a/golem-db/src/schema.rs
+++ b/golem-db/src/schema.rs
@@ -41,11 +41,28 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    savestates (id) {
+        id -> Integer,
+        name -> Nullable<Text>,
+        core_id -> Integer,
+        game_id -> Integer,
+        path -> Text,
+        screenshot_path -> Nullable<Text>,
+        favorite -> Bool,
+        created_at -> Timestamp,
+        last_played -> Nullable<Timestamp>,
+    }
+}
+
 diesel::joinable!(dat_files -> cores (core_id));
 diesel::joinable!(games -> cores (core_id));
+diesel::joinable!(savestates -> cores (core_id));
+diesel::joinable!(savestates -> games (game_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     cores,
     dat_files,
     games,
+    savestates,
 );

--- a/golem/Cargo.toml
+++ b/golem/Cargo.toml
@@ -53,6 +53,7 @@ num-integer = "0.1.45"
 num-traits = "0.2.15"
 once_cell = "1.18.0"
 ouroboros = "0.18.0"
+parking_lot = "0.12.1"
 qrcode = { version = "0.12.0", features = ["image"] }
 regex = "1.9.3"
 reqwest = { version = "0.11.22", features = ["blocking", "json", "rustls-tls"], default-features = false }

--- a/golem/src/application.rs
+++ b/golem/src/application.rs
@@ -1,3 +1,4 @@
+use crate::application::coordinator::Coordinator;
 use crate::application::menu::main_menu;
 use crate::application::toolbar::Toolbar;
 use crate::data::settings::Settings;
@@ -21,6 +22,8 @@ pub mod panels;
 mod toolbar;
 mod widgets;
 
+pub mod coordinator;
+
 use crate::data::paths;
 
 pub struct GoLEmApp {
@@ -28,12 +31,14 @@ pub struct GoLEmApp {
     settings: Arc<Settings>,
     database: Arc<Mutex<Connection>>,
 
+    coordinator: Coordinator,
+
     render_toolbar: bool,
 
     joysticks: [Option<Joystick>; 32],
     gamepads: [Option<Gamepad>; 32],
 
-    pub platform: WindowManager,
+    platform: WindowManager,
     main_buffer: DrawBuffer<BinaryColor>,
     toolbar_buffer: DrawBuffer<BinaryColor>,
 }
@@ -64,6 +69,7 @@ impl GoLEmApp {
 
         Self {
             toolbar: Toolbar::new(settings.clone(), database.clone()),
+            coordinator: Coordinator::new(database.clone()),
             render_toolbar: true,
             joysticks,
             gamepads,
@@ -104,6 +110,10 @@ impl GoLEmApp {
 
     pub fn show_toolbar(&mut self) {
         self.render_toolbar = true;
+    }
+
+    pub fn coordinator_mut(&mut self) -> Coordinator {
+        self.coordinator.clone()
     }
 
     pub fn event_loop<R>(

--- a/golem/src/application/coordinator.rs
+++ b/golem/src/application/coordinator.rs
@@ -1,0 +1,214 @@
+use crate::application::GoLEmApp;
+use crate::data::paths;
+use crate::platform::{Core, CoreManager, GoLEmPlatform};
+use golem_db::models::Core as DbCore;
+use golem_db::models::Game as DbGame;
+use golem_db::Connection;
+use image::DynamicImage;
+use std::fmt::{Debug, Formatter};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use tracing::{info, trace};
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct GameStartInfo {
+    core_id: Option<i32>,
+    game_id: Option<i32>,
+    save_state_id: Option<i32>,
+}
+
+impl GameStartInfo {
+    pub fn with_core_id(mut self, core_id: i32) -> Self {
+        self.core_id = Some(core_id);
+        self
+    }
+
+    pub fn with_maybe_core_id(mut self, core_id: Option<i32>) -> Self {
+        self.core_id = core_id;
+        self
+    }
+
+    pub fn with_game_id(mut self, game_id: i32) -> Self {
+        self.game_id = Some(game_id);
+        self
+    }
+
+    pub fn with_save_state_id(mut self, save_state_id: i32) -> Self {
+        self.save_state_id = Some(save_state_id);
+        self
+    }
+}
+
+struct CoordinatorInner {
+    current_core: Option<DbCore>,
+    current_game: Option<DbGame>,
+
+    database: Arc<Mutex<Connection>>,
+}
+
+impl Debug for CoordinatorInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CoordinatorInner")
+            .field("current_core", &self.current_core)
+            .field("current_game", &self.current_game)
+            .finish()
+    }
+}
+
+impl CoordinatorInner {
+    pub(super) fn new(database: Arc<Mutex<Connection>>) -> Self {
+        Self {
+            database,
+            current_core: None,
+            current_game: None,
+        }
+    }
+
+    pub fn launch_game(
+        &mut self,
+        app: &mut GoLEmApp,
+        info: GameStartInfo,
+    ) -> Result<(bool, impl Core), String> {
+        info!(?info, "Starting game");
+        let mut database = self.database.lock().unwrap();
+
+        let core = match info.core_id {
+            Some(id) => DbCore::get(&mut database, id)
+                .map_err(|e| e.to_string())?
+                .ok_or("Core not found")?,
+            None => self.current_core.clone().ok_or("No core selected")?,
+        };
+
+        // Load the core
+        let mut c = app
+            .platform_mut()
+            .core_manager_mut()
+            .load_core(&core.path)?;
+        self.current_core = Some(core);
+        self.current_game = None;
+        let mut should_show_menu = true;
+
+        // Load the game
+        if let Some(game) = info.game_id {
+            let mut game = DbGame::get(&mut database, game)
+                .map_err(|e| e.to_string())?
+                .ok_or("Game not found")?;
+            let game_path = game.path.as_ref().ok_or("No file path for game")?;
+            c.load_file(Path::new(game_path), None)?;
+
+            // Record in the Database the time we launched this game, ignoring
+            // errors.
+            let _ = game.play(&mut database);
+            self.current_game = Some(game);
+            should_show_menu = false;
+        }
+
+        // Load all savestates for this game.
+        if let Some(game) = &self.current_game {
+            if let Some(core_ss) = c.save_states() {
+                let db_ss = golem_db::models::SaveState::list_for_game(&mut database, game.id)
+                    .map_err(|e| e.to_string())?;
+
+                for (db_state, state) in db_ss.iter().zip(core_ss.iter_mut()) {
+                    let f = std::fs::File::open(&db_state.path).map_err(|e| e.to_string())?;
+                    state.read_from(f)?;
+                }
+            }
+        }
+
+        // Load the savestate requested in the first slot.
+        if let Some(savestate) = info.save_state_id {
+            let savestate = golem_db::models::SaveState::get(&mut database, savestate)
+                .map_err(|e| e.to_string())?
+                .ok_or("Savestate not found")?;
+
+            if let Some(state) = c.save_states().and_then(|x| x.get_mut(0)) {
+                let f = std::fs::File::open(&savestate.path).map_err(|e| e.to_string())?;
+                state.read_from(f)?;
+            }
+        }
+
+        Ok((should_show_menu, c))
+    }
+
+    pub fn create_savestate(
+        &mut self,
+        slot: usize,
+        screenshot: Option<&DynamicImage>,
+    ) -> Result<std::fs::File, String> {
+        let core = self.current_core.as_ref().ok_or("No core loaded")?;
+        let game = self.current_game.as_ref().ok_or("No game loaded")?;
+        let mut database = self.database.lock().unwrap();
+        let ss_root = paths::savestates_path(&core.slug);
+        if !ss_root.exists() {
+            std::fs::create_dir_all(&ss_root).map_err(|e| e.to_string())?;
+        }
+
+        let name = &game.name;
+        let savestate_path: PathBuf = ss_root.join(format!("{name}_{slot}")).with_extension("ss");
+        let screenshot_path = if screenshot.is_some() {
+            Some(savestate_path.with_extension("ss.png"))
+        } else {
+            None
+        };
+
+        trace!(?savestate_path, ?screenshot_path, "Saving save state");
+
+        if let Some(s) = screenshot {
+            s.save(&screenshot_path.clone().unwrap())
+                .map_err(|e| e.to_string())?;
+        }
+
+        let ss = golem_db::models::SaveState::create(
+            &mut database,
+            core.id,
+            game.id,
+            savestate_path.to_string_lossy().to_string(),
+            screenshot_path.map(|x| x.to_string_lossy().to_string()),
+        )
+        .map_err(|e| e.to_string())?;
+
+        let f = std::fs::File::create(&ss.path).map_err(|e| e.to_string())?;
+        Ok(f)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Coordinator {
+    inner: Arc<Mutex<CoordinatorInner>>,
+}
+
+impl Coordinator {
+    pub fn new(database: Arc<Mutex<Connection>>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(CoordinatorInner::new(database))),
+        }
+    }
+
+    pub fn launch_game(
+        &mut self,
+        app: &mut GoLEmApp,
+        info: GameStartInfo,
+    ) -> Result<(bool, impl Core), String> {
+        self.inner.lock().unwrap().launch_game(app, info)
+    }
+
+    pub fn current_core(&self) -> Option<DbCore> {
+        self.inner.lock().unwrap().current_core.clone()
+    }
+
+    pub fn current_game(&self) -> Option<DbGame> {
+        self.inner.lock().unwrap().current_game.clone()
+    }
+
+    pub fn create_savestate(
+        &self,
+        slot: usize,
+        screenshot: Option<&DynamicImage>,
+    ) -> Result<std::fs::File, String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .create_savestate(slot, screenshot)
+    }
+}

--- a/golem/src/application/menu/cores/list.rs
+++ b/golem/src/application/menu/cores/list.rs
@@ -131,7 +131,7 @@ pub fn cores_menu_panel(app: &mut GoLEmApp) {
                 info!("Loading core from path {:?}", path);
 
                 let manager = app.platform_mut().core_manager_mut();
-                match manager.load_program(std::path::Path::new(&path)) {
+                match manager.load_core(std::path::Path::new(&path)) {
                     Ok(core) => {
                         run_core_loop(app, core, true);
                     }
@@ -158,7 +158,7 @@ pub fn cores_menu_panel(app: &mut GoLEmApp) {
                 info!("Loading core from path {:?}", path);
 
                 if let Ok(Some(path)) = path {
-                    match app.platform_mut().core_manager_mut().load_program(&path) {
+                    match app.platform_mut().core_manager_mut().load_core(&path) {
                         Ok(core) => {
                             run_core_loop(app, core, true);
                         }

--- a/golem/src/application/menu/games.rs
+++ b/golem/src/application/menu/games.rs
@@ -1,13 +1,12 @@
+use crate::application::coordinator::GameStartInfo;
 use crate::application::menu::games::manage::manage_games;
 use crate::application::menu::style::MenuReturn;
 use crate::application::menu::{text_menu, TextMenuOptions};
 use crate::application::panels::alert::show_error;
 use crate::application::panels::core_loop::run_core_loop;
 use crate::application::GoLEmApp;
-use crate::platform::{Core, CoreManager, GoLEmPlatform};
 use anyhow::anyhow;
 use golem_db::models::GameOrder;
-use std::path::PathBuf;
 use thiserror::__private::AsDynError;
 
 mod details;
@@ -43,13 +42,10 @@ fn build_games_list_(
     sort: GameOrder,
 ) -> Vec<golem_db::models::Game> {
     let all_games = golem_db::models::Game::list(database, 0, 1000, sort);
-    match all_games {
-        Ok(all_games) => all_games,
-        Err(e) => {
-            tracing::error!("Database error: {e}");
-            Vec::new()
-        }
-    }
+    all_games.unwrap_or_else(|e| {
+        tracing::error!("Database error: {e}");
+        Vec::new()
+    })
 }
 
 pub fn games_list(app: &mut GoLEmApp) {
@@ -82,55 +78,26 @@ pub fn games_list(app: &mut GoLEmApp) {
             MenuAction::Manage => manage_games(app),
             MenuAction::LoadGame(i) => {
                 let game = &mut all_games[i];
-                let file_path = match game.path.as_ref() {
-                    Some(path) => path,
-                    None => {
-                        show_error(app, anyhow!("No file path for game").as_dyn_error(), true);
-                        return;
-                    }
-                };
-                let file_path = PathBuf::from(file_path);
-                let core_path = if let Some(core_id) = game.core_id {
-                    let core =
-                        golem_db::models::Core::get(&mut app.database().lock().unwrap(), core_id)
-                            .unwrap()
-                            .unwrap();
-                    PathBuf::from(core.path)
-                } else {
-                    show_error(app, anyhow!("No core for game").as_dyn_error(), true);
-                    return;
-                };
 
-                // Load the core
-                match app
-                    .platform_mut()
-                    .core_manager_mut()
-                    .load_program(&core_path)
-                {
-                    Ok(mut core) => {
-                        if let Err(e) = core.load_file(&file_path, None) {
-                            show_error(
-                                app,
-                                anyhow!("Failed to load file: {}", e).as_dyn_error(),
-                                true,
-                            );
-                        } else {
-                            // Record in the Database the time we launched this game, ignoring
-                            // errors.
-                            let _ = game.play(&mut app.database().lock().unwrap());
-
-                            run_core_loop(app, core, false);
-                        }
-                    }
+                let (should_show_menu, core) = match app.coordinator_mut().launch_game(
+                    app,
+                    GameStartInfo::default()
+                        .with_maybe_core_id(game.core_id)
+                        .with_game_id(game.id),
+                ) {
+                    Ok((should_show_menu, core)) => (should_show_menu, core),
                     Err(e) => {
                         show_error(
                             app,
-                            anyhow!("Failed to load core: {}", e).as_dyn_error(),
+                            anyhow!("Failed to start game: {}", e).as_dyn_error(),
                             true,
                         );
                         return;
                     }
-                }
+                };
+
+                // Run the core loop.
+                run_core_loop(app, core, should_show_menu);
             }
             MenuAction::ShowDetails(i) => {
                 let game = &mut all_games[i];

--- a/golem/src/application/menu/main.rs
+++ b/golem/src/application/menu/main.rs
@@ -6,7 +6,6 @@ use crate::application::panels::alert::alert;
 use crate::application::panels::settings::settings_panel;
 use crate::application::panels::tools::tools_menu;
 use crate::application::GoLEmApp;
-use crate::platform;
 use golem_db::models;
 
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
@@ -53,7 +52,7 @@ pub fn main_menu(app: &mut GoLEmApp) {
         match result {
             MenuAction::Games => games_list(app),
             MenuAction::Cores => cores_menu_panel(app),
-            MenuAction::Settings => settings_panel(app, &None::<&mut dyn platform::Core>),
+            MenuAction::Settings => settings_panel(app, &None::<&mut crate::platform::CoreType>),
             MenuAction::Tools => tools_menu(app),
             MenuAction::About => {
                 alert(app, "About", "Not implemented", &["Okay"]);

--- a/golem/src/application/panels/core_loop/menu/input_mapping.rs
+++ b/golem/src/application/panels/core_loop/menu/input_mapping.rs
@@ -24,7 +24,7 @@ impl MenuReturn for MenuAction {
     }
 }
 
-pub fn menu(app: &mut GoLEmApp, core: &Option<&mut (impl Core + ?Sized)>) {
+pub fn menu<C: Core + ?Sized>(app: &mut GoLEmApp, core: &Option<&mut C>) {
     let mut state = None;
 
     loop {
@@ -59,7 +59,7 @@ pub fn menu(app: &mut GoLEmApp, core: &Option<&mut (impl Core + ?Sized)>) {
             .map(|(a, b, c)| (*a, b.as_str(), *c))
             .collect::<Vec<_>>();
 
-        let menu = if let Some(c) = core {
+        let menu = if let Some(c) = &core {
             let menu = c.menu_options();
             menu.iter()
                 .filter_map(|config_menu| {

--- a/golem/src/application/panels/settings.rs
+++ b/golem/src/application/panels/settings.rs
@@ -20,7 +20,10 @@ impl MenuReturn for MenuAction {
     }
 }
 
-pub fn settings_panel(app: &mut GoLEmApp, core: &Option<&mut (impl Core + ?Sized)>) {
+pub fn settings_panel<C: Core + ?Sized>(app: &mut GoLEmApp, core: &Option<&mut C>)
+where
+    C: Sized,
+{
     let mut state = None;
     loop {
         let (result, new_state) = text_menu(

--- a/golem/src/data/paths.rs
+++ b/golem/src/data/paths.rs
@@ -34,6 +34,18 @@ pub fn core_root_path() -> PathBuf {
     p
 }
 
+pub fn savestates_root_path() -> PathBuf {
+    let p = config_root_path().join("savestates");
+    if !p.exists() {
+        std::fs::create_dir_all(&p).unwrap();
+    }
+    p
+}
+
+pub fn savestates_path(core_name: &str) -> PathBuf {
+    savestates_root_path().join(core_name)
+}
+
 pub fn core_root(core: &retronomicon_dto::cores::CoreListItem) -> PathBuf {
     core_root_path().join(&core.slug)
 }

--- a/golem/src/platform/de10.rs
+++ b/golem/src/platform/de10.rs
@@ -16,7 +16,7 @@ use tracing::{debug, error};
 pub use mister_fpga::fpga;
 
 mod battery;
-mod core_manager;
+pub mod core_manager;
 mod input;
 mod offload;
 mod osd;

--- a/golem/src/platform/de10/core_manager.rs
+++ b/golem/src/platform/de10/core_manager.rs
@@ -22,7 +22,7 @@ impl CoreManager {
         &mut self.fpga
     }
 
-    fn load(&mut self, program: &[u8]) -> Result<MisterFpgaCore, String> {
+    fn load(&mut self, program: &[u8]) -> Result<core::MisterFpgaCore, String> {
         let program = if &program[..6] != b"MiSTer" {
             program
         } else {
@@ -51,14 +51,14 @@ impl CoreManager {
                 std::ptr::null(),
             );
         }
-        Ok(core)
+        Ok(core::MisterFpgaCore::new(core))
     }
 }
 
 impl crate::platform::CoreManager for CoreManager {
-    type Core = MisterFpgaCore;
+    type Core = core::MisterFpgaCore;
 
-    fn load_program(&mut self, path: impl AsRef<Path>) -> Result<MisterFpgaCore, String> {
+    fn load_core(&mut self, path: impl AsRef<Path>) -> Result<Self::Core, String> {
         let bytes = std::fs::read(path.as_ref()).map_err(|e| e.to_string())?;
         let core = self.load(&bytes)?;
         Ok(core)

--- a/golem/src/platform/de10/core_manager/core.rs
+++ b/golem/src/platform/de10/core_manager/core.rs
@@ -1,40 +1,90 @@
 use crate::platform::Core;
 use image::DynamicImage;
 use mister_fpga::config_string::{ConfigMenu, LoadFileInfo};
-use mister_fpga::core::MisterFpgaCore;
 use mister_fpga::types::StatusBitMap;
 use sdl3::gamepad::{Axis, Button};
 use sdl3::keyboard::Scancode;
-use std::path::Path;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+pub struct MisterFpgaCore {
+    inner: mister_fpga::core::MisterFpgaCore,
+    loaded_file: Option<PathBuf>,
+}
+
+impl MisterFpgaCore {
+    pub fn new(inner: mister_fpga::core::MisterFpgaCore) -> Self {
+        Self {
+            inner,
+            loaded_file: None,
+        }
+    }
+}
+
+impl crate::platform::SaveState for mister_fpga::savestate::SaveState {
+    fn is_dirty(&self) -> bool {
+        self.is_dirty()
+    }
+
+    fn write_to(&mut self, writer: impl std::io::Write) -> Result<(), String> {
+        self.write_to(writer).map_err(|e| e.to_string())
+    }
+
+    fn read_from(&mut self, reader: impl Read) -> Result<(), String> {
+        self.read_from(reader).map_err(|e| e.to_string())
+    }
+}
 
 impl Core for MisterFpgaCore {
+    type SaveState = mister_fpga::savestate::SaveState;
+
     fn name(&self) -> &str {
-        &self.config().name
+        &self.inner.config().name
+    }
+
+    fn current_game(&self) -> Option<&Path> {
+        self.loaded_file.as_deref()
     }
 
     fn load_file(&mut self, path: &Path, file_info: Option<LoadFileInfo>) -> Result<(), String> {
-        self.send_file(path, file_info)
+        let update = file_info.as_ref().map(|l| l.index == 0).unwrap_or(true);
+        self.inner.send_file(path, file_info)?;
+        if update {
+            self.loaded_file = Some(path.to_path_buf());
+        }
+
+        Ok(())
     }
 
     fn version(&self) -> Option<&str> {
-        self.config().version()
+        self.inner.config().version()
     }
 
     fn menu_options(&self) -> &[ConfigMenu] {
-        self.config().menu.as_slice()
+        self.inner.config().menu.as_slice()
     }
 
     fn trigger_menu(&mut self, menu: &ConfigMenu) -> Result<bool, String> {
         match menu {
             ConfigMenu::HideIf(cond, sub) | ConfigMenu::DisableIf(cond, sub) => {
-                if self.config().status_bit_map_mask().get(*cond as usize) {
+                if self
+                    .inner
+                    .config()
+                    .status_bit_map_mask()
+                    .get(*cond as usize)
+                {
                     self.trigger_menu(sub)
                 } else {
                     Err("Cannot trigger menu".to_string())
                 }
             }
             ConfigMenu::HideUnless(cond, sub) | ConfigMenu::DisableUnless(cond, sub) => {
-                if !self.config().status_bit_map_mask().get(*cond as usize) {
+                if !self
+                    .inner
+                    .config()
+                    .status_bit_map_mask()
+                    .get(*cond as usize)
+                {
                     self.trigger_menu(sub)
                 } else {
                     Err("Cannot trigger menu".to_string())
@@ -42,7 +92,7 @@ impl Core for MisterFpgaCore {
             }
             ConfigMenu::Option { bits, choices, .. } => {
                 let (from, to) = (bits.start, bits.end);
-                let mut bits = *self.status_bits();
+                let mut bits = self.status_bits();
                 let max = choices.len();
                 let value = bits.get_range(from..to) as usize;
                 bits.set_range(from..to, ((value + 1) % max) as u32);
@@ -61,38 +111,44 @@ impl Core for MisterFpgaCore {
     }
 
     fn status_mask(&self) -> StatusBitMap {
-        self.config().status_bit_map_mask()
+        self.inner.config().status_bit_map_mask()
     }
 
     fn status_bits(&self) -> StatusBitMap {
-        *self.status_bits()
+        *self.inner.status_bits()
     }
 
     fn set_status_bits(&mut self, bits: StatusBitMap) {
-        self.send_status_bits(bits)
+        self.inner.send_status_bits(bits)
     }
 
     fn take_screenshot(&mut self) -> Result<DynamicImage, String> {
-        self.take_screenshot()
+        self.inner.take_screenshot()
     }
 
     fn key_down(&mut self, key: Scancode) {
-        self.key_down(key)
+        self.inner.key_down(key)
     }
 
     fn key_up(&mut self, key: Scancode) {
-        self.key_up(key)
+        self.inner.key_up(key)
     }
 
     fn sdl_button_down(&mut self, controller: u8, button: Button) {
-        self.gamepad_button_down(controller, button as u8)
+        self.inner.gamepad_button_down(controller, button as u8)
     }
 
     fn sdl_button_up(&mut self, controller: u8, button: Button) {
-        self.gamepad_button_up(controller, button as u8)
+        self.inner.gamepad_button_up(controller, button as u8)
     }
 
     fn sdl_axis_motion(&mut self, _controller: u8, _axis: Axis, _value: i16) {
         // TODO: do this.
+    }
+
+    fn save_states(&mut self) -> Option<&mut [Self::SaveState]> {
+        self.inner
+            .save_states_mut()
+            .map(|manager| manager.as_slice_mut())
     }
 }

--- a/golem/src/platform/desktop.rs
+++ b/golem/src/platform/desktop.rs
@@ -14,12 +14,29 @@ use mister_fpga::types::StatusBitMap;
 use sdl3::event::Event;
 use sdl3::gamepad::{Axis, Button};
 use sdl3::keyboard::Scancode;
+use std::io::Read;
 use std::path::Path;
 use tracing::info;
+
+impl crate::platform::SaveState for () {
+    fn is_dirty(&self) -> bool {
+        false
+    }
+
+    fn write_to(&mut self, _write: impl std::io::Write) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn read_from(&mut self, reader: impl Read) -> Result<(), String> {
+        Ok(())
+    }
+}
 
 pub struct DummyCore;
 
 impl Core for DummyCore {
+    type SaveState = ();
+
     fn name(&self) -> &str {
         "DummyCore"
     }
@@ -57,8 +74,12 @@ impl Core for DummyCore {
         unreachable!()
     }
 
-    fn send_key(&mut self, key: Scancode) {
-        info!("DummyCore::send_key({})", key);
+    fn key_down(&mut self, key: Scancode) {
+        info!("DummyCore::key_down({})", key);
+    }
+
+    fn key_up(&mut self, key: Scancode) {
+        info!("DummyCore::key_up({})", key);
     }
 
     fn sdl_button_down(&mut self, joystick_idx: u8, button: Button) {
@@ -83,6 +104,10 @@ impl Core for DummyCore {
             controller, axis, value
         );
     }
+
+    fn save_states(&mut self) -> Option<&mut [()]> {
+        None
+    }
 }
 
 pub struct DummyCoreManager;
@@ -90,8 +115,8 @@ pub struct DummyCoreManager;
 impl CoreManager for DummyCoreManager {
     type Core = DummyCore;
 
-    fn load_program(&mut self, path: impl AsRef<Path>) -> Result<Self::Core, String> {
-        info!("DummyCoreManager::load_program({:?})", path.as_ref());
+    fn load_core(&mut self, path: impl AsRef<Path>) -> Result<Self::Core, String> {
+        info!("DummyCoreManager::load_core({:?})", path.as_ref());
         Ok(DummyCore)
     }
 

--- a/golem/src/platform/null.rs
+++ b/golem/src/platform/null.rs
@@ -72,7 +72,7 @@ pub struct NullCoreManager;
 impl super::CoreManager for NullCoreManager {
     type Core = NullCore;
 
-    fn load_program(&mut self, _path: impl AsRef<Path>) -> Result<Self::Core, String> {
+    fn load_core(&mut self, _path: impl AsRef<Path>) -> Result<Self::Core, String> {
         unreachable!("Platform should never run in NULL.")
     }
 

--- a/mister-fpga/src/config_string.rs
+++ b/mister-fpga/src/config_string.rs
@@ -306,6 +306,10 @@ impl Config {
         Self::from_str(&cfg_string)
     }
 
+    pub fn settings(&self) -> &settings::Settings {
+        &self.settings
+    }
+
     pub fn status_bit_map_mask(&self) -> StatusBitMap {
         let mut arr = StatusBitMap::new();
         // First bit is always 1 for soft reset (reserved).

--- a/mister-fpga/src/config_string/settings.rs
+++ b/mister-fpga/src/config_string/settings.rs
@@ -3,7 +3,6 @@ use super::{midi, FpgaRamMemoryAddress};
 use crate::types::units::UnitConversion;
 use std::convert::TryFrom;
 use std::fmt::Debug;
-use std::ops::Range;
 use std::str::FromStr;
 
 #[derive(Default, Clone)]

--- a/mister-fpga/src/core.rs
+++ b/mister-fpga/src/core.rs
@@ -11,6 +11,7 @@ use crate::fpga::user_io::{
 };
 use crate::fpga::{CoreInterfaceType, CoreType, MisterFpga};
 use crate::keyboard::Ps2Scancode;
+use crate::savestate::Savestate;
 use crate::types::StatusBitMap;
 use cyclone_v::memory::{DevMemMemoryMapper, MemoryMapper};
 use image::DynamicImage;
@@ -154,6 +155,8 @@ impl MisterFpgaCore {
         // Disable download.
         self.fpga.spi_mut().execute(FileIoFileTxDisabled)
     }
+
+    pub fn save_state(&mut self) -> Savestate {}
 
     pub fn config(&self) -> &config_string::Config {
         &self.config

--- a/mister-fpga/src/core.rs
+++ b/mister-fpga/src/core.rs
@@ -57,6 +57,7 @@ pub struct MisterFpgaCore {
     pub io_version: u8,
     config: config_string::Config,
 
+    save_states: Option<SaveStateManager<DevMemMemoryMapper>>,
     map: ButtonMap,
 
     status: StatusBitMap,
@@ -88,13 +89,15 @@ impl MisterFpgaCore {
         info!("Core config: {:#?}", config);
         fpga.wait_for_ready();
 
+        let save_states = SaveStateManager::from_config_string(&config);
+
         Ok(MisterFpgaCore {
             fpga,
             core_type,
             spi_type,
             io_version,
             config,
-            // mapping,
+            save_states,
             map,
             status: Default::default(),
         })
@@ -155,8 +158,6 @@ impl MisterFpgaCore {
         // Disable download.
         self.fpga.spi_mut().execute(FileIoFileTxDisabled)
     }
-
-    pub fn save_state(&mut self) -> Savestate {}
 
     pub fn config(&self) -> &config_string::Config {
         &self.config

--- a/mister-fpga/src/core.rs
+++ b/mister-fpga/src/core.rs
@@ -11,7 +11,7 @@ use crate::fpga::user_io::{
 };
 use crate::fpga::{CoreInterfaceType, CoreType, MisterFpga};
 use crate::keyboard::Ps2Scancode;
-use crate::savestate::Savestate;
+use crate::savestate::SaveStateManager;
 use crate::types::StatusBitMap;
 use cyclone_v::memory::{DevMemMemoryMapper, MemoryMapper};
 use image::DynamicImage;
@@ -217,6 +217,14 @@ impl MisterFpgaCore {
             .spi_mut()
             .execute(UserIoJoystick::from_joystick_index(joystick_idx, &self.map))
             .unwrap();
+    }
+
+    pub fn save_states(&self) -> Option<&SaveStateManager<DevMemMemoryMapper>> {
+        self.save_states.as_ref()
+    }
+
+    pub fn save_states_mut(&mut self) -> Option<&mut SaveStateManager<DevMemMemoryMapper>> {
+        self.save_states.as_mut()
     }
 
     pub fn take_screenshot(&mut self) -> Result<DynamicImage, String> {

--- a/mister-fpga/src/fpga/spi/user_io.rs
+++ b/mister-fpga/src/fpga/spi/user_io.rs
@@ -89,7 +89,6 @@ impl From<u32> for UserIoKeyboardKeyDown {
 impl SpiCommand for UserIoKeyboardKeyDown {
     #[inline]
     fn execute<S: SpiCommandExt>(&mut self, spi: &mut S) -> Result<(), String> {
-        eprintln!("UserIoKeyboardKeyDown: {:08x}", self.0);
         spi.command(UserIoCommands::UserIoKeyboard)
             .write_cond_b(self.0 & 0x080000 != 0, 0xE0)
             .write_b((self.0 & 0xFF) as u8);

--- a/mister-fpga/src/keyboard.rs
+++ b/mister-fpga/src/keyboard.rs
@@ -437,10 +437,6 @@ pub enum Ps2Scancode {
 
 impl From<SdlScancode> for Ps2Scancode {
     fn from(scancode: SdlScancode) -> Self {
-        eprintln!(
-            "scancode: {:?} {} SDL3_TO_PS2[scancode as u8]: {:?}",
-            scancode, scancode as u8, SDL3_TO_PS2[scancode as u8]
-        );
         SDL3_TO_PS2[scancode as u8].unwrap_or(Ps2Scancode::None)
     }
 }

--- a/mister-fpga/src/lib.rs
+++ b/mister-fpga/src/lib.rs
@@ -5,5 +5,6 @@ pub mod core_info;
 pub mod fpga;
 pub mod framebuffer;
 pub mod osd;
+pub mod savestate;
 pub mod types;
 pub mod keyboard;

--- a/mister-fpga/src/savestate.rs
+++ b/mister-fpga/src/savestate.rs
@@ -1,0 +1,101 @@
+use crate::config_string::Config;
+use cyclone_v::memory::{DevMemMemoryMapper, MemoryMapper};
+use std::io::{Read, Write};
+
+const DEFAULT_MISTER_SAVESTATE_SLOTS: u32 = 4;
+
+pub struct SaveStateManager<M: MemoryMapper> {
+    memory: M,
+    nb_slots: u32,
+    slots: Vec<SaveState<'static>>,
+}
+
+impl SaveStateManager<DevMemMemoryMapper> {
+    pub fn from_config_string(config: &Config) -> Option<Self> {
+        let (base, size) = config.settings().save_state?;
+        let nb_slots = DEFAULT_MISTER_SAVESTATE_SLOTS;
+
+        // The memory setup is:
+        //   0x00: u32 change detector.     A value that changes when the savestate changes.
+        //   0x04: u32 size                 Save of the savestate, in bytes.
+        //   0x08..0x08+size                The savestate data.
+
+        let mut memory = DevMemMemoryMapper::create(base.as_usize(), size * 4).unwrap();
+        let slots = (0..nb_slots)
+            .map(|i| {
+                let base = (i as usize) * size;
+                let change_detector: &mut u32 =
+                    &mut unsafe { *memory.as_mut_ptr::<u8>().add(base) as _ };
+                let size = &mut unsafe { *memory.as_mut_ptr::<u8>().add(base + 4) as _ };
+                let data = memory.as_mut_range((base + 8)..*size as usize);
+                SaveState {
+                    change_detector,
+                    size,
+                    data,
+                }
+            })
+            .collect();
+
+        Some(Self {
+            nb_slots,
+            memory,
+            slots,
+        })
+    }
+}
+
+impl<M: MemoryMapper> SaveStateManager<M> {
+    pub fn nb_slots(&self) -> u32 {
+        self.nb_slots
+    }
+
+    pub fn save_state_mut(&mut self, slot: u32) -> Option<&mut SaveState<'_>> {
+        self.slots.get_mut(slot as usize)
+    }
+}
+
+pub struct SaveState<'a> {
+    change_detector: &'a mut u32,
+    size: &'a mut u32,
+    data: &'a mut [u8],
+}
+
+impl<'a> SaveState<'a> {
+    pub fn save(&mut self, mut writer: impl Write) -> Result<(), String> {
+        let sz = *self.size;
+        writer
+            .write_all(&self.change_detector.to_be_bytes())
+            .map_err(|e| e.to_string())?;
+        writer
+            .write_all(&self.size.to_be_bytes())
+            .map_err(|e| e.to_string())?;
+        writer
+            .write_all(&(&self.data)[..(sz as usize)])
+            .map_err(|e| e.to_string())?;
+        *self.change_detector = 0xFFFFFFFF;
+        Ok(())
+    }
+
+    pub fn load(&mut self, mut reader: impl Read) -> Result<(), String> {
+        let mut change_detector = [0u8; 4];
+        let mut sz = [0u8; 4];
+        reader
+            .read_exact(&mut change_detector)
+            .map_err(|e| e.to_string())?;
+        reader.read_exact(&mut sz).map_err(|e| e.to_string())?;
+        let sz = u32::from_be_bytes(sz);
+        if sz >= self.data.len() as u32 {
+            return Err("Save state too large".to_string());
+        }
+
+        *self.change_detector = u32::from_be_bytes(change_detector);
+        *self.size = sz;
+
+        reader
+            .read_exact(self.data[..self.size])
+            .map_err(|e| e.to_string())?;
+        *self.size = sz as u32;
+        *self.change_detector = 0xFFFFFFFF;
+        Ok(())
+    }
+}

--- a/mister-fpga/src/savestate.rs
+++ b/mister-fpga/src/savestate.rs
@@ -7,7 +7,7 @@ const DEFAULT_MISTER_SAVESTATE_SLOTS: u32 = 4;
 pub struct SaveStateManager<M: MemoryMapper> {
     memory: M,
     nb_slots: u32,
-    slots: Vec<SaveState<'static>>,
+    slots: Vec<SaveState>,
 }
 
 impl SaveStateManager<DevMemMemoryMapper> {
@@ -20,19 +20,12 @@ impl SaveStateManager<DevMemMemoryMapper> {
         //   0x04: u32 size                 Save of the savestate, in bytes.
         //   0x08..0x08+size                The savestate data.
 
-        let mut memory = DevMemMemoryMapper::create(base.as_usize(), size * 4).unwrap();
+        let mut memory =
+            DevMemMemoryMapper::create(base.as_usize(), size * (nb_slots as usize)).unwrap();
         let slots = (0..nb_slots)
             .map(|i| {
-                let base = (i as usize) * size;
-                let change_detector: &mut u32 =
-                    &mut unsafe { *memory.as_mut_ptr::<u8>().add(base) as _ };
-                let size = &mut unsafe { *memory.as_mut_ptr::<u8>().add(base + 4) as _ };
-                let data = memory.as_mut_range((base + 8)..*size as usize);
-                SaveState {
-                    change_detector,
-                    size,
-                    data,
-                }
+                let offset = (i as usize) * size;
+                SaveState::from_base(&mut memory, offset)
             })
             .collect();
 
@@ -45,34 +38,73 @@ impl SaveStateManager<DevMemMemoryMapper> {
 }
 
 impl<M: MemoryMapper> SaveStateManager<M> {
-    pub fn nb_slots(&self) -> u32 {
-        self.nb_slots
+    pub fn iter(&self) -> impl Iterator<Item = &SaveState> {
+        self.slots.iter()
     }
 
-    pub fn save_state_mut(&mut self, slot: u32) -> Option<&mut SaveState<'_>> {
-        self.slots.get_mut(slot as usize)
+    // pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut SaveState<'_>> + '_ {
+    //     // self.slots.iter_mut()
+    //     todo!()
+    // }
+
+    pub fn nb_slots(&self) -> usize {
+        self.nb_slots as usize
     }
 }
 
-pub struct SaveState<'a> {
-    change_detector: &'a mut u32,
-    size: &'a mut u32,
-    data: &'a mut [u8],
+pub struct SaveState {
+    change_detector: *mut u32,
+    size: *mut u32,
+    data: *mut u8,
 }
 
-impl<'a> SaveState<'a> {
+impl SaveState {
+    fn from_base(memory: &mut impl MemoryMapper, offset: usize) -> Self {
+        let change_detector = unsafe { memory.as_mut_ptr::<u8>().add(offset) as _ };
+        let size: *mut u32 = unsafe { memory.as_mut_ptr::<u8>().add(offset + 4) as _ };
+        let data = unsafe { memory.as_mut_ptr::<u8>().add(offset + 8) };
+
+        Self {
+            change_detector,
+            size,
+            data,
+        }
+    }
+}
+
+impl SaveState {
+    pub fn size(&self) -> usize {
+        unsafe { *self.size as usize }
+    }
+
+    pub fn change_detector(&self) -> u32 {
+        unsafe { *self.change_detector }
+    }
+
+    pub(crate) fn reset_change_detector(&mut self) {
+        unsafe { *self.change_detector = 0xFFFFFFFF }
+    }
+
+    pub fn data(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.data, self.size()) }
+    }
+
+    fn data_mut(&self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.data, self.size()) }
+    }
+
     pub fn save(&mut self, mut writer: impl Write) -> Result<(), String> {
-        let sz = *self.size;
+        let sz = self.size();
         writer
-            .write_all(&self.change_detector.to_be_bytes())
+            .write_all(&self.change_detector().to_be_bytes())
             .map_err(|e| e.to_string())?;
         writer
-            .write_all(&self.size.to_be_bytes())
+            .write_all(&sz.to_be_bytes())
             .map_err(|e| e.to_string())?;
         writer
-            .write_all(&(&self.data)[..(sz as usize)])
+            .write_all(&self.data()[..(sz as usize)])
             .map_err(|e| e.to_string())?;
-        *self.change_detector = 0xFFFFFFFF;
+        self.reset_change_detector();
         Ok(())
     }
 
@@ -84,18 +116,19 @@ impl<'a> SaveState<'a> {
             .map_err(|e| e.to_string())?;
         reader.read_exact(&mut sz).map_err(|e| e.to_string())?;
         let sz = u32::from_be_bytes(sz);
-        if sz >= self.data.len() as u32 {
+        if sz >= self.data().len() as u32 {
             return Err("Save state too large".to_string());
         }
 
-        *self.change_detector = u32::from_be_bytes(change_detector);
-        *self.size = sz;
+        unsafe {
+            *self.change_detector = u32::from_be_bytes(change_detector);
+            *self.size = sz;
+        }
 
         reader
-            .read_exact(self.data[..self.size])
+            .read_exact(&mut self.data_mut()[..(self.size() as usize)])
             .map_err(|e| e.to_string())?;
-        *self.size = sz as u32;
-        *self.change_detector = 0xFFFFFFFF;
+        self.reset_change_detector();
         Ok(())
     }
 }


### PR DESCRIPTION
Savestates are supported for now per-game in the database. Running a core and loading a ROM will not load the savestates properly (yet). Any cores that support save states should work though.

A screenshot is taken when the savestate is saved.